### PR TITLE
Add CI config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  build-coq:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: "recursive"
+      - uses: coq-community/docker-coq-action@v1
+        with:
+          coq_version: "8.20"
+          ocaml_version: "default"
+          install: ""
+          before_script: |
+            sudo chown -R coq:coq .
+          script: |
+            startGroup Build
+              make -j4 -k vok
+            endGroup
+          uninstall: |
+            make clean
+      - name: Revert permissions
+        if: ${{ always() }}
+        run: sudo chown -R 1001:116 .
+
+  build-go:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Go
+        uses: actions/setup-go@v5
+
+      - name: Check style
+        run: |
+          gofmt -w -s .
+          git diff --exit-code
+
+      - name: Install dependencies
+        run: go get -t ./...
+      - name: go test
+        run: go test -vet=all -v ./...
+
+      - name: Check goose output
+        run: |
+          go run github.com/goose-lang/goose/cmd/goose@latest -out example/goose ./example
+          git diff --exit-code

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,6 @@ clean:
 	$(Q)find $(SRC_DIRS) \( -name "*.vo" -o -name "*.vo[sk]" \
 		-o -name ".*.aux" -o -name ".*.cache" -name "*.glob" \) -delete
 	$(Q)rm -f .timing.sqlite3
-	$(Q)find src/software_foundations \( -not -name "impdriver.ml" \
-		-name "*.ml" -o -name "*.mli" \) -delete
 	rm -f .coqdeps.d
 
 .PHONY: default

--- a/README.org
+++ b/README.org
@@ -7,6 +7,12 @@ and emitting the Go code which can perform the marshaling and unmarshaling of
 the described buffers and a Gallina script which enables reasoning about the
 marshaling process.
 
+** Usage
+
+Re-run goose: ~goose -out example/goose ./example~
+
+Run test: ~go run ./example~
+
 ** Why "Grackle"
 
 A [[https://en.wikipedia.org/wiki/Common_grackle][grackle]] is a bird capable of mimicking other birds and even human speech if it


### PR DESCRIPTION
The CI builds the Coq proofs and Go code, checks `gofmt`, and also checks that the generated Goose is up-to-date.

It's running `go test`, which both builds the code and runs `go vet` even if there are no tests to run (hopefully there will be tests at some point).